### PR TITLE
Add support for C-stick and touchscreen mouse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ARCH	:=	-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft
 CFLAGS	:=	-g -Wall -O3 -mword-relocations \
 			-fomit-frame-pointer -ffunction-sections \
 			$(ARCH)
-DEFINES	:=	-DARM11 -D_3DS  -DNDS_VERS_STRING=\"$(VERS_STRING)\" \
+DEFINES	:=	-D__3DS__  -DNDS_VERS_STRING=\"$(VERS_STRING)\" \
 			-D_NDS -DNONET -DNO_IPV6 -DNOHS -DNOMD5 -DHAVE_BLUA -DHWRENDER -DNOPOSTPROCESSING -DNOSPLITSCREEN -DDIAGNOSTIC
 
 CFLAGS	+=	$(INCLUDE) $(DEFINES)
@@ -68,7 +68,7 @@ CFLAGS	+=	$(INCLUDE) $(DEFINES)
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 
 ASFLAGS	:=	-g $(ARCH)
-LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
+LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map) -z muldefs
 
 LIBS	:= -lSDL_mixer -lmikmod -lmad -lvorbisidec -logg -lSDL -lcitro3d -lctru -lm
 

--- a/source/g_game.c
+++ b/source/g_game.c
@@ -316,6 +316,9 @@ static CV_PossibleValue_t joyaxis_cons_t[] = {{0, "None"},
 #if JOYAXISSET > 3
 {7, "LAnalog"}, {8, "RAnalog"}, {-7, "LAnalog-"}, {-8, "RAnalog-"},
 #endif
+#elif defined(__3DS__)
+{1, "Circ.Pad X"}, {2, "Circ.Pad Y"}, {3, "C-Stick X"}, {4, "C-Stick Y"},
+{-1, "Circ.Pad -X"}, {-2, "Circ.Pad -Y"}, {-3, "C-Stick -X"}, {-4, "C-Stick -Y"},
 #else
 {1, "X-Axis"}, {2, "Y-Axis"}, {-1, "X-Axis-"}, {-2, "Y-Axis-"},
 #ifdef _arch_dreamcast
@@ -377,15 +380,25 @@ typedef enum
 	AXISFIRENORMAL,
 } axis_input_e;
 
-#if defined (_WII) || defined  (WMINPUT)
+#if defined(__3DS__)
+consvar_t cv_turnaxis = {"joyaxis_turn", "Circ.Pad X", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_moveaxis = {"joyaxis_move", "Circ.Pad -Y", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_sideaxis = {"joyaxis_side", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_lookaxis = {"joyaxis_look", "C-Stick Y", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_lookxaxis = {"joyaxis_lookx", "C-Stick X", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_fireaxis = {"joyaxis_fire", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_firenaxis = {"joyaxis_firenormal", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+#elif defined (_WII) || defined  (WMINPUT)
 consvar_t cv_turnaxis = {"joyaxis_turn", "LStick.X", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_moveaxis = {"joyaxis_move", "LStick.Y", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_sideaxis = {"joyaxis_side", "RStick.X", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_lookaxis = {"joyaxis_look", "RStick.Y", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_lookxaxis = {"joyaxis_lookx", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_fireaxis = {"joyaxis_fire", "LAnalog", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_firenaxis = {"joyaxis_firenormal", "RAnalog", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #else
 consvar_t cv_turnaxis = {"joyaxis_turn", "X-Axis", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_lookxaxis = {"joyaxis_lookx", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #ifdef PSP
 consvar_t cv_moveaxis = {"joyaxis_move", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #else
@@ -412,7 +425,14 @@ consvar_t cv_fireaxis = {"joyaxis_fire", "None", CV_SAVE, joyaxis_cons_t, NULL, 
 consvar_t cv_firenaxis = {"joyaxis_firenormal", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 #endif
 
-#if defined (_WII) || defined  (WMINPUT)
+#ifdef __3DS__
+consvar_t cv_turnaxis2 = {"joyaxis2_turn", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_moveaxis2 = {"joyaxis2_move", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_sideaxis2 = {"joyaxis2_side", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_lookaxis2 = {"joyaxis2_look", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_fireaxis2 = {"joyaxis2_fire", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+consvar_t cv_firenaxis2 = {"joyaxis2_firenormal", "None", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
+#elif defined (_WII) || defined  (WMINPUT)
 consvar_t cv_turnaxis2 = {"joyaxis2_turn", "LStick.X", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_moveaxis2 = {"joyaxis2_move", "LStick.Y", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};
 consvar_t cv_sideaxis2 = {"joyaxis2_side", "RStick.X", CV_SAVE, joyaxis_cons_t, NULL, 0, NULL, NULL, 0, 0, NULL};

--- a/source/nds/i_system.c
+++ b/source/nds/i_system.c
@@ -29,7 +29,6 @@ u32 __stacksize__ = 0x180000;
 u32 __ctru_linear_heap_size = 48 * 1024 * 1024;
 
 float sliderState = 0.0f;
-
 //----------------------------
 
 UINT32 I_GetFreeMem(UINT32 *total)
@@ -65,6 +64,7 @@ static bool isInGame()
 
 void I_GetEvent(void)
 {
+	static touchPosition last_touch_position;
 	// set of keys we care about
 	const u32 dskeys[] =
 	{
@@ -105,6 +105,7 @@ void I_GetEvent(void)
 	up = keysUp();
 	down = keysDown();
 
+
 	sliderState = osGet3DSliderState();
 
 	{
@@ -124,6 +125,27 @@ void I_GetEvent(void)
 		
 		D_PostEvent(&event);
 
+		
+		hidCstickRead(&cpos);
+		event.data1=1;
+		event.data2 = cpos.dx*amplifier;
+		event.data3 = cpos.dy*amplifier;
+		D_PostEvent(&event);
+		
+		
+		/* Touchscreen emulates a trackpad */
+		if(keysHeld() & KEY_TOUCH) {
+			touchPosition current_touch_position;
+			hidTouchRead(&current_touch_position);
+			if (!(keysDown() & KEY_TOUCH)) {
+				event.type = ev_mouse;
+				event.data1 = 0;
+				event.data2 = current_touch_position.px - last_touch_position.px;
+				event.data3 = current_touch_position.py - last_touch_position.py;
+				D_PostEvent(&event);
+			}
+			last_touch_position = current_touch_position;
+		}
 
 		/* For the buttons, we need to report changes in state */
 		for (i = 0; i < sizeof(dskeys)/sizeof(dskeys[0]); i++)


### PR DESCRIPTION
The code previously supported using the New 3DS C-stick as a 4-way D-pad.  I added support for using it as a second analog stick, and updated the axis names in the settings menu to refer to the 3DS instead of generic HID joysticks.  I also added support for using the touch screen as a trackpad which gets sent to the game as mouse input.  Neither of these new inputs are scaled in any way before being sent to the engine, because I wasn't sure what to scale them by.

I also updated the makefile so it'll build with the latest version of the toolchain.  In my fork, I also commented out the definition of `__dmb` in source/nds_utils.h since an identical definition now exists in libctru.  I did not commit this change since you had already modified that file.  You can ignore either or both of those ancillary changes if they would mess something else up.